### PR TITLE
Updated node version specified in the ".nvmrc" file to "lts/iron" so …

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron


### PR DESCRIPTION
## 🗒️ Summary

Updated Node.js version specified in the ".nvmrc" file to "lts/iron" so that wds, wds-react, and our frontend application for the portal are in sync with each other to avoid issues when using `npm link`.

## ⚙️ Test Data and/or Report
* Tested building of icons and css using `wds` codebase
* Tested `npm link` command from `wds` codebase to ensure package gets published locally:

```
anatha@MT-407379 wds % npm link

up to date, audited 3 packages in 357ms

found 0 vulnerabilities
anatha@MT-407379 wds % npm list -g      
/Users/anatha/.nvm/versions/node/v20.16.0/lib
├── @nasapds/wds-react@0.1.0 -> ./../../../../../Projects/PDS/Engineering Node/Repos/wds-react
├── @nasapds/wds@0.0.1 -> ./../../../../../Projects/PDS/Engineering Node/Repos/wds
├── corepack@0.28.2
└── npm@10.8.1

anatha@MT-407379 wds % 
```

* Tested `npm link @nasapds/wds` command from `wds-react` codebase:

```
anatha@MT-407379 wds-react % npm link @nasapds/wds
npm warn deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm warn deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs

up to date, audited 1591 packages in 4s
....
```

## ♻️ Related Issues
-Resolves #46 

