### PR TITLE
Added styles for call to action button

### DIFF
--- a/scss/button.scss
+++ b/scss/button.scss
@@ -1,0 +1,13 @@
+
+.wds-button-cta {
+  color: var(--pds-primary-white);
+  background-color: var(--pds-primary-red);
+  height: 44px;
+  padding: 12px 20px;
+  border-radius: 0;
+  font-size: 16px;
+}
+
+.wds-button-cta:hover {
+  background-color: var(--pds-secondary-red-s1);
+}

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -1,2 +1,3 @@
 @import "variables.scss";
+@import "button.scss";
 @import "typography.scss";

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -116,7 +116,7 @@
   --pds-typography-header-16-regular-font-size: 16px;
   --pds-typography-header-16-regular-line-height: 20px;
   --pds-typography-header-16-regular-letter-spacing: -0.5px;
-  --pds-typography-header-16-regular-font-weight: normal.
+  --pds-typography-header-16-regular-font-weight: normal;
 
   --pds-typography-header-14-semibold-font-size: 14px;
   --pds-typography-header-14-semibold-line-height: 19px;


### PR DESCRIPTION
## 🗒️ Summary
Added styles for call to action buttons. Also fixed a broken typography style.

## ⚙️ Test Data and/or Report
run `npm run build:icons`

Link to wds-react  `search-page-components` branch and run `npm run build-lib`

Link wds-react to portal-wp `features/prototype-search-page` branch.  To go /search

View the cta button in the search bar. It should look like this:
<img width="104" alt="Screenshot 2024-09-04 at 3 49 13 PM" src="https://github.com/user-attachments/assets/085bc639-d813-4ba3-bfef-f27a6520bbce">


## ♻️ Related Issues
refs https://github.com/NASA-PDS/portal-wp-tasks/issues/58
This is needed to run the current portal-wp `features/prototype-search-page` branch


